### PR TITLE
Improve job distribution to avoid lost jobs

### DIFF
--- a/src/clojurecast/scheduler.clj
+++ b/src/clojurecast/scheduler.clj
@@ -10,8 +10,6 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:dynamic *test-mode* false)
-
 (def ^:dynamic *job*)
 
 (defn ^com.hazelcast.core.IMap cluster-jobs
@@ -146,9 +144,7 @@
 
 (defn- job-timeout
   ^long [^com.hazelcast.core.IAtomicReference job-ref]
-  (if *test-mode*
-    0
-    (:job/timeout (.get job-ref))))
+  (:job/timeout (.get job-ref)))
 
 (defn- run-job
   [job-id ^ScheduledThreadPoolExecutor exec tasks]


### PR DESCRIPTION
This PR fixes several bugs or missing features:
- Jobs were being lost when members were removed from the cluster
- Job message handlers were not being recreated when members were added, losing events
- Jobs were not being redistributed when members were added

Additional problems appear to remain, however, related to maintaining correct state.  This may be a result of corruption in job state from the above bugs however.
